### PR TITLE
ES-526 Trivy scanner security issued

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN make build &&\
 
 
 # driver container
-FROM alpine:3.10
+FROM alpine:3.15
 LABEL name="nexentastor-csi-driver"
 LABEL maintainer="Nexenta Systems, Inc."
 LABEL description="NexentaStor CSI Driver"


### PR DESCRIPTION
Root Cause :  Trivy scanner shows the following security vulnerabilities
Critical CVE-2021-36159 apk-tools (need version 2.10.7)
High CVE-2020-14040 golang.org/x/text (need version 0.3.3)
High CVE-2019-11253 k8s.io/kubernetes (need version 1.14.8)
High CVE-2020-8558 k8s.io/kubernetes (need version 1.16.11)
High CVE-2021-25741 k8s.io/kubernetes (need version 1.19.15)
Proposed Fix : Bump dependant image version to those that have the issues fixed
Testing Done : trivy image nexentastor-csi-driver:master
