### PR TITLE
bumped alpine version to 3.15.4 to fix CVE-2022-28391

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN make build &&\
 
 
 # driver container
-FROM alpine:3.15
+FROM alpine:3.15.4
 LABEL name="nexentastor-csi-driver"
 LABEL maintainer="Nexenta Systems, Inc."
 LABEL description="NexentaStor CSI Driver"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,10 @@ pipeline {
         }
         stage('Tests [local registry]') {
             when {
-                branch 'master'
+	        anyOf {
+		    branch 'master';
+		    branch pattern: '^\d\.\d\.\d', comparator: 'REGEXP'
+		}
             }
             steps {
                 sh "TEST_K8S_IP=${params.TEST_K8S_IP} TESTRAIL_URL=${TESTRAIL_URL} TESTRAIL_USR=${TESTRAIL_USR} TESTRAIL_PSWD=${TESTRAIL_PSW} make test-e2e-k8s-local-image-container"
@@ -52,7 +55,10 @@ pipeline {
         }
         stage('Push [hub.docker.com]') {
             when {
-                branch 'master'
+	        anyOf {
+		    branch 'master';
+		    branch pattern: '^\d\.\d\.\d', comparator: 'REGEXP'
+		}
             }
             environment {
                 DOCKER = credentials('docker-hub-credentials')
@@ -66,7 +72,10 @@ pipeline {
         }
         stage('Tests [k8s hub.docker.com]') {
             when {
-                branch 'master'
+	        anyOf {
+		    branch 'master';
+		    branch pattern: '^\d\.\d\.\d', comparator: 'REGEXP'
+		}
             }
             steps {
                 sh "TEST_K8S_IP=${params.TEST_K8S_IP} TESTRAIL_URL=${TESTRAIL_URL} TESTRAIL_USR=${TESTRAIL_USR} TESTRAIL_PSWD=${TESTRAIL_PSW} make test-e2e-k8s-remote-image-container"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,10 +44,10 @@ pipeline {
         }
         stage('Tests [local registry]') {
             when {
-	        anyOf {
-		    branch 'master';
-		    branch pattern: '^\d\.\d\.\d', comparator: 'REGEXP'
-		}
+                anyOf {
+                    branch 'master'
+                    branch pattern: '\\d\\.\\d\\.\\d', comparator: 'REGEXP'
+                }
             }
             steps {
                 sh "TEST_K8S_IP=${params.TEST_K8S_IP} TESTRAIL_URL=${TESTRAIL_URL} TESTRAIL_USR=${TESTRAIL_USR} TESTRAIL_PSWD=${TESTRAIL_PSW} make test-e2e-k8s-local-image-container"
@@ -55,10 +55,10 @@ pipeline {
         }
         stage('Push [hub.docker.com]') {
             when {
-	        anyOf {
-		    branch 'master';
-		    branch pattern: '^\d\.\d\.\d', comparator: 'REGEXP'
-		}
+                anyOf {
+                    branch 'master'
+                    branch pattern: '\\d\\.\\d\\.\\d', comparator: 'REGEXP'
+                }
             }
             environment {
                 DOCKER = credentials('docker-hub-credentials')
@@ -72,10 +72,10 @@ pipeline {
         }
         stage('Tests [k8s hub.docker.com]') {
             when {
-	        anyOf {
-		    branch 'master';
-		    branch pattern: '^\d\.\d\.\d', comparator: 'REGEXP'
-		}
+                anyOf {
+                    branch 'master'
+                    branch pattern: '\\d\\.\\d\\.\\d', comparator: 'REGEXP'
+                }
             }
             steps {
                 sh "TEST_K8S_IP=${params.TEST_K8S_IP} TESTRAIL_URL=${TESTRAIL_URL} TESTRAIL_USR=${TESTRAIL_USR} TESTRAIL_PSWD=${TESTRAIL_PSW} make test-e2e-k8s-remote-image-container"


### PR DESCRIPTION
Root Cause : Trivy scanner shows the following security vulnerabilities
nexentastor-csi-driver:master (alpine 3.15.0)

Total: 6 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 4, CRITICAL: 2)

+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
|   LIBRARY    | VULNERABILITY ID | SEVERITY | INSTALLED VERSION | FIXED VERSION |                 TITLE                 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| busybox      | CVE-2022-28391   | CRITICAL | 1.34.1-r3         | 1.34.1-r5     | BusyBox through 1.35.0 allows         |
|              |                  |          |                   |               | remote attackers to execute           |
|              |                  |          |                   |               | arbitrary code if netstat...          |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-28391 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| libcrypto1.1 | CVE-2022-0778    | HIGH     | 1.1.1l-r7         | 1.1.1n-r0     | openssl: Infinite loop in             |
|              |                  |          |                   |               | BN_mod_sqrt() reachable               |
|              |                  |          |                   |               | when parsing certificates             |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-0778  |
+--------------+                  +          +-------------------+---------------+                                       +
| libretls     |                  |          | 3.3.4-r2          | 3.3.4-r3      |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
+--------------+                  +          +-------------------+---------------+                                       +
| libssl1.1    |                  |          | 1.1.1l-r7         | 1.1.1n-r0     |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
|              |                  |          |                   |               |                                       |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| ssl_client   | CVE-2022-28391   | CRITICAL | 1.34.1-r3         | 1.34.1-r5     | BusyBox through 1.35.0 allows         |
|              |                  |          |                   |               | remote attackers to execute           |
|              |                  |          |                   |               | arbitrary code if netstat...          |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2022-28391 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
| zlib         | CVE-2018-25032   | HIGH     | 1.2.11-r3         | 1.2.12-r0     | zlib: A flaw found in                 |
|              |                  |          |                   |               | zlib when compressing (not            |
|              |                  |          |                   |               | decompressing) certain inputs...      |
|              |                  |          |                   |               | -->avd.aquasec.com/nvd/cve-2018-25032 |
+--------------+------------------+----------+-------------------+---------------+---------------------------------------+
Proposed Fix : Bump dependant image version to those that have the issues fixed
Testing Done : trivy image nexentastor-csi-driver:master
