### PR TITLE
ES-535 update to newest versions of sidecar containers

### DIFF
--- a/deploy/kubernetes/nexentastor-csi-driver.yaml
+++ b/deploy/kubernetes/nexentastor-csi-driver.yaml
@@ -60,7 +60,7 @@ rules:
     verbs: ['list', 'watch', 'create', 'update', 'patch']
   # attacher specific
   - apiGroups: ['']
-    resources: ['nodes']
+    resources: ['nodes', 'pods']
     verbs: ['get', 'list', 'watch']
   - apiGroups: ['csi.storage.k8s.io']
     resources: ['csinodeinfos']
@@ -74,7 +74,7 @@ rules:
     verbs: ['get', 'list', 'watch']
   - apiGroups: ['snapshot.storage.k8s.io']
     resources: ['volumesnapshotcontents']
-    verbs: ['create', 'get', 'list', 'watch', 'update', 'delete']
+    verbs: ['create', 'get', 'list', 'watch', 'update', 'delete', 'patch']
   - apiGroups: ['snapshot.storage.k8s.io']
     resources: ['volumesnapshots']
     verbs: ['get', 'list', 'watch', 'update']
@@ -211,7 +211,7 @@ spec:
         # csi-provisioner: sidecar container that watches Kubernetes PersistentVolumeClaim objects
         # and triggers CreateVolume/DeleteVolume against a CSI endpoint
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/var/lib/csi/sockets/pluginproxy/csi.sock
@@ -223,7 +223,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-snapshotter
-          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
           imagePullPolicy: IfNotPresent
           args:
             - -v=3
@@ -232,7 +232,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -340,7 +340,7 @@ spec:
         # 1) registers the CSI driver with kubelet
         # 2) adds the drivers custom NodeId to a label on the Kubernetes Node API Object
         - name: driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
           imagePullPolicy: IfNotPresent
           args:
             - --v=3

--- a/deploy/kubernetes/snapshots/crds.yaml
+++ b/deploy/kubernetes/snapshots/crds.yaml
@@ -1,3 +1,4 @@
+# kubectl create -f deploy/kubernetes/snapshots/crds.yaml
 
 ---
 apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
Root cause: outdated sidecar containers had security vulnerabilities
Proposed fix: update sidecar containers to latest available releases
Testing done: manual + sanity tests