### PR TITLE
ES-537 add worker-threads and timeout params to csi-provisioner

### DIFF
--- a/deploy/kubernetes/nexentastor-csi-driver.yaml
+++ b/deploy/kubernetes/nexentastor-csi-driver.yaml
@@ -219,6 +219,8 @@ spec:
             - --strict-topology
             - --immediate-topology=false
             - --feature-gates=Topology=true
+            - --timeout=300s
+            - --worker-threads=2
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy

--- a/tests/deploy/scripts/stress-test/nexentastor-csi-driver-config.yaml
+++ b/tests/deploy/scripts/stress-test/nexentastor-csi-driver-config.yaml
@@ -1,0 +1,13 @@
+nexentastor_map:
+  nstor-sanity-box1:
+    restIp: https://10.3.199.190:8443
+    username: admin
+    password: Nexenta@1
+    defaultDataset: qa/nfs_share
+    defaultDataIp: 10.3.199.192
+    defaultMountFsType: nfs
+    defaultMountOptions: nolock,vers=4 # only vers=4 works in container
+    v13Compatibility: true
+    # zone: local
+
+debug: true


### PR DESCRIPTION
Root cause: CSI-provisioner has defaults for worker-threads=100 and timeout=30s which can lead to NexentaStor backend being unable to process mass parallel requests in 30s which leads to kubernetes retrying the operation and stack the API calls.
Proposed solution: Set worker-threads=2 and timeout=300
Testing done: manual and sanity